### PR TITLE
Adding some additional options to compass

### DIFF
--- a/src/main/groovy/org/gradle/plugins/compass/CompassExtension.groovy
+++ b/src/main/groovy/org/gradle/plugins/compass/CompassExtension.groovy
@@ -9,7 +9,19 @@ class CompassExtension {
 	File sassDir
 	File imagesDir
 	File javascriptsDir
+  File fontsDir
 
 	boolean relativeAssets
+  boolean boring
+  boolean debugInfo
+  boolean dryRun
+  boolean force
+  boolean noLineComments
+  boolean quiet
+  boolean trace
+
+  String environment
+  String outputStyle
+  String projectType
 
 }

--- a/src/main/groovy/org/gradle/plugins/compass/CompassPlugin.groovy
+++ b/src/main/groovy/org/gradle/plugins/compass/CompassPlugin.groovy
@@ -53,6 +53,16 @@ class CompassPlugin implements Plugin<Project> {
 			sassDir = project.file('src/main/sass')
 			imagesDir = project.file('src/main/images')
 			javascriptsDir = project.file('src/main/scripts')
+
+      File defaultFontDir = new File('src/main/fonts')
+      if (defaultFontDir.exists()) {
+        fontsDir = project.file(defaultFontDir)
+      }
+
+      projectType = 'stand_alone'
+      environment = 'development'
+      outputStyle = 'compact'
+      debugInfo = true
 		}
 	}
 
@@ -70,6 +80,17 @@ class CompassPlugin implements Plugin<Project> {
 				imagesDir = { extension.imagesDir }
 				javascriptsDir = { extension.javascriptsDir }
 				relativeAssets = { extension.relativeAssets }
+        projectType = { extension.projectType }
+        environment = { extension.environment }
+        outputStyle = { extension.outputStyle }
+        fontsDir = { extension.fontsDir }
+        noLineComments = { extension.noLineComments }
+        debugInfo = { extension.debugInfo }
+        quiet = { extension.quiet }
+        trace = { extension.trace }
+        force = { extension.force }
+        dryRun = { extension.dryRun }
+        boring = { extension.boring }
 			}
 		}
 	}

--- a/src/main/groovy/org/gradle/plugins/compass/CompassTask.groovy
+++ b/src/main/groovy/org/gradle/plugins/compass/CompassTask.groovy
@@ -7,13 +7,29 @@ class CompassTask extends JRubyTask {
 
 	String command
 	boolean background
+
 	boolean relativeAssets
+  boolean boring
+  boolean debugInfo
+  boolean dryRun
+  boolean force
+  boolean noLineComments
+  boolean quiet
+  boolean trace
+
+  String environment
+  String outputStyle
+  String projectType
 
 	@InputDirectory
 	File gemPath
 
 	@OutputDirectory
 	File cssDir
+
+  @InputDirectory
+  @Optional
+  File fontsDir
 
 	@InputDirectory
 	File sassDir
@@ -42,6 +58,25 @@ class CompassTask extends JRubyTask {
 		if (getRelativeAssets()) {
 			args << '--relative-assets'
 		}
+
+    args << '--app' << getProjectType()
+    args << '--environment' << getEnvironment()
+    args << '--output-style' << getOutputStyle()
+
+    if (getDebugInfo()) {
+      args << '--debug-info'
+    } else {
+      args << '--no-debug-info'
+    }
+
+    if (getBoring()) { args << '--boring' }
+    if (getDryRun()) { args << '--dry-run' }
+    if (getFontsDir()) { args << '--fonts-dir' << getFontsDir() }
+    if (getForce()) { args << '--force' }
+    if (getNoLineComments()) { args << '--no-line-comments' }
+    if (getQuiet()) { args << '--quiet' }
+    if (getTrace()) { args << '--trace' }
+
 		return args
 	}
 


### PR DESCRIPTION
Apparently we both decided to work on a sass plugin at about the same time and after trying to create a fairly complicated embedded JRuby script using the Sass::Plugin directly I've found that your plugin's approach is actually faster. Some of my generated css files can be fairly large so I wanted to add the outputStyle option so that :compressed could be selected and I went ahead and added some of the other options from the compass script. 
