### PR TITLE
Fixing issue 13 with pathing for images

### DIFF
--- a/src/main/groovy/org/gradle/plugins/compass/CompassTask.groovy
+++ b/src/main/groovy/org/gradle/plugins/compass/CompassTask.groovy
@@ -92,7 +92,7 @@ class CompassTask extends JRubyTask {
   }
 
   String getImagesDirRelativeToProjectPath() {
-    return (getImagesDir().path - project.projectDir.path)[1..-1]
+    return project.projectDir.path.toURI().relativize( getImagesDir().path.toURI() ).toString()
   }
 
   @TaskAction


### PR DESCRIPTION
https://github.com/robfletcher/gradle-compass/issues/13

I'm pretty sure this will allow you to maintain a relative path when the images dir is a child of the project root and absolute path when it's not.