### PR TITLE
accept options to gem install

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,25 @@ processResources.inputs.files compileSass
 run.dependsOn watchSass
 clean.dependsOn cleanCompileSass
 ```
+#### Advanced Gem Install Options
+
+You can specify additional options to `gem install`:
+
+```groovy
+compass {
+	gems = [
+		[
+			name: "compass",
+			version: "0.12.7",
+		],
+		[
+			name: "compass-css-arrow",
+			version: "0.0.4",
+			opts: ["--ignore-dependencies"],
+		],
+	]
+}
+```
 
 # Version history
 

--- a/src/main/groovy/org/gradle/plugins/compass/CompassExtension.groovy
+++ b/src/main/groovy/org/gradle/plugins/compass/CompassExtension.groovy
@@ -8,7 +8,7 @@ class CompassExtension {
   String encoding
   String jvmArgs
   String jrubyVersion
-  Collection<String> gems
+  Collection gems
   Collection<String> gemJars
 
 

--- a/src/main/groovy/org/gradle/plugins/compass/DependenciesResolver.groovy
+++ b/src/main/groovy/org/gradle/plugins/compass/DependenciesResolver.groovy
@@ -38,6 +38,7 @@ class DependenciesResolver extends JRubyTask {
     args << '-i' << getGemPath()
     args << '--no-rdoc'
     args << '--no-ri'
+    args.addAll(rubyGem.opts)
     args << rubyGem.name
     if (rubyGem.version != null) {
       args << '-v'

--- a/src/main/groovy/org/gradle/plugins/compass/JRubyTask.groovy
+++ b/src/main/groovy/org/gradle/plugins/compass/JRubyTask.groovy
@@ -13,7 +13,7 @@ abstract class JRubyTask extends DefaultTask {
   String jvmArgs
 
   @Input
-  Collection<String> gems
+  Collection gems
 
   @Input
   Collection<String> gemJars

--- a/src/main/groovy/org/gradle/plugins/compass/RubyGem.groovy
+++ b/src/main/groovy/org/gradle/plugins/compass/RubyGem.groovy
@@ -3,6 +3,9 @@ package org.gradle.plugins.compass
 class RubyGem {
   String name
   String version
+  Collection<String> opts = []
+
+  RubyGem() {} // XXX enables the Map constructor
 
   public RubyGem(String gemString) {
     if (gemString?.contains(":")) {


### PR DESCRIPTION
Background: Our build broke recently due to compass 1.0.1 coming out and changing a behavior of `@extend`. At this point we realized we didn't have the compass version locked down.  Specifying `"compass:0.12.7"` wasn't enough because another gem we installed (e.g., `compass-css-arrow`) was still pulling in compass `1.0.1`. The only way I could find to actually lock down our compass version was to pass `--ignore-dependencies` to the install command for the other gems.

So this PR adds an escape hatch to pass options to `gem install`. That lets us specify `--ignore-dependencies` and lock the version down.