### PR TITLE
Making cleanCompileSass use a white list for deleting files

### DIFF
--- a/src/main/groovy/org/gradle/plugins/compass/CompassPlugin.groovy
+++ b/src/main/groovy/org/gradle/plugins/compass/CompassPlugin.groovy
@@ -33,6 +33,12 @@ class CompassPlugin implements Plugin<Project> {
       outputs.upToDateWhen { false }
     }
 
+    project.task('cleanCompileTask') << {
+      fileTree(dir: extension.cssDir, include: '**/*.css').each {
+        delete it
+      }
+    }
+
     compileSass.dependsOn(installCompass)
     watchSass.dependsOn(installCompass)
 
@@ -51,7 +57,7 @@ class CompassPlugin implements Plugin<Project> {
     }
   }
 
-    private void createExtension() {
+  private void createExtension() {
     extension = project.extensions.create('compass', CompassExtension)
     extension.with {
       encoding = Charset.defaultCharset().name()


### PR DESCRIPTION
I'm working on a project where `sassDir` is a subdirectory in the `cssDir`. Running `cleanCompileSass` deletes `sassDir`. I'm not sure if you want the plugin to subscribe to a white-filtered approach to cleaning but here it is.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/robfletcher/gradle-compass/26)

<!-- Reviewable:end -->
