### PR TITLE
Adding jcenter to the repositories

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -37,6 +37,7 @@ apply plugin: "com.github.robfletcher.compass"
 buildscript {
   repositories {
     mavenCentral()
+    jcenter()
     maven { url "http://dl.bintray.com/robfletcher/gradle-plugins" }
   }
   dependencies {


### PR DESCRIPTION
Without jcenter, gradle is not able to resolve gradle-proceess plugin and its dependencies:

```Could not find com.github.jengelman.gradle.plugins:gradle-processes:0.3.0```