### PR TITLE
Java 7 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ apply from: "$rootDir/gradle/credentials.gradle"
 group = "com.github.robfletcher"
 version = "2.0.5"
 archivesBaseName = "compass-gradle-plugin"
+sourceCompatibility = 1.7
 
 repositories {
   jcenter()

--- a/src/test/groovy/com/github/robfletcher/compass/CompassDependencySpec.groovy
+++ b/src/test/groovy/com/github/robfletcher/compass/CompassDependencySpec.groovy
@@ -7,7 +7,7 @@ class CompassDependencySpec extends CompassPluginSpec {
     runTasks "compassVersion"
 
     then:
-    standardOutput.readLines().contains "Compass 1.0.1 (Polaris)"
+    standardOutput.readLines().contains "Compass 1.0.3 (Polaris)"
   }
 
   def "can specify compass version"() {


### PR DESCRIPTION
The latest release requires Java 8. Java 7 is not yet EOL, so it would be nice to have a compatible release. Define the minimum java version that the plugin is compatible with in build.gradle via the sourceCompatibility property.

I also fixed a failing test, which depends on the latest compass release.