### PR TITLE
Update jruby-gradle to 0.1.17

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -158,7 +158,7 @@ compass {
 
 = Version history
 
-=== 2.0.5
+=== 2.0.6
 
 * Fixes JDK version compatibility so plugin can be used with Java 1.7.
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ repositories {
 dependencies {
   compile gradleApi()
   compile localGroovy()
-  compile "com.github.jruby-gradle:jruby-gradle-plugin:0.1.9"
+  compile "com.github.jruby-gradle:jruby-gradle-plugin:0.1.17"
   compile "com.github.jengelman.gradle.plugins:gradle-processes:0.3.0"
 
   testCompile("org.spockframework:spock-core:0.7-groovy-2.0") {


### PR DESCRIPTION
0.1.17 is the latest version which works ootB with the gradle-compass-plugin. Also have tried 0.2.2 and 0.3.0 which need more affort and knowledge to integrate.

The update of the version was necessary because on windows an error occured 'Could not load FFI Provider' see https://github.com/jruby-gradle/jruby-gradle-plugin/issues/83 for more details.