### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -40,7 +40,7 @@ buildscript {
     maven { url "http://dl.bintray.com/robfletcher/gradle-plugins" }
   }
   dependencies {
-    classpath "com.github.robfletcher:compass-gradle-plugin:2.0.5"
+    classpath "com.github.robfletcher:compass-gradle-plugin:2.0.6"
   }
 }
 ----
@@ -158,7 +158,7 @@ compass {
 
 = Version history
 
-=== 2.0.5
+=== 2.0.6
 
 * Fixes JDK version compatibility so plugin can be used with Java 1.7.
 


### PR DESCRIPTION
Description fixed. 2.0.5 points to a  Java 7 incompatible version.