### PR TITLE
Upgrade dependencies to the latest versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,15 +5,17 @@ buildscript {
   dependencies {
     classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:0.6"
     classpath "org.gradle.api.plugins:gradle-nexus-plugin:0.7.1"
+    classpath "com.github.ben-manes:gradle-versions-plugin:0.12.0"
   }
 }
+apply plugin: 'com.github.ben-manes.versions'
 apply plugin: "com.jfrog.bintray"
 apply plugin: "groovy"
 apply plugin: "nexus"
 apply from: "$rootDir/gradle/credentials.gradle"
 
 group = "com.github.robfletcher"
-version = "2.0.6"
+version = "2.0.7"
 archivesBaseName = "compass-gradle-plugin"
 sourceCompatibility = 1.7
 
@@ -34,16 +36,16 @@ repositories {
 dependencies {
   compile gradleApi()
   compile localGroovy()
-  compile "com.github.jruby-gradle:jruby-gradle-plugin:0.1.9"
+  compile "com.github.jruby-gradle:jruby-gradle-plugin:1.2.0"
   compile "com.github.jengelman.gradle.plugins:gradle-processes:0.3.0"
 
-  testCompile("org.spockframework:spock-core:0.7-groovy-2.0") {
+  testCompile("org.spockframework:spock-core:1.0-groovy-2.4") {
     exclude group: "org.codehaus.groovy"
   }
-  testCompile("com.netflix.nebula:nebula-test:2.0.4") {
+  testCompile("com.netflix.nebula:nebula-test:4.0.0") {
     exclude group: "org.codehaus.groovy"
   }
-  testCompile "net.sourceforge.cssparser:cssparser:0.9.14"
+  testCompile "net.sourceforge.cssparser:cssparser:0.9.18"
 }
 
 test {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.11-all.zip

--- a/src/main/groovy/com/github/robfletcher/compass/CompassPlugin.groovy
+++ b/src/main/groovy/com/github/robfletcher/compass/CompassPlugin.groovy
@@ -21,7 +21,7 @@ class CompassPlugin implements Plugin<Project> {
     project.afterEvaluate {
       def configuration = project.configurations.getByName(CONFIGURATION_NAME)
       if (!configuration.dependencies.any { it.name == "compass" }) {
-        project.dependencies.add(CONFIGURATION_NAME, "rubygems:compass:1.0.3")
+        project.dependencies.add(CONFIGURATION_NAME, "rubygems:compass:[0.0,)")
       }
     }
 

--- a/src/main/groovy/com/github/robfletcher/compass/CompassPlugin.groovy
+++ b/src/main/groovy/com/github/robfletcher/compass/CompassPlugin.groovy
@@ -1,6 +1,7 @@
 package com.github.robfletcher.compass
 
 import com.github.jrubygradle.JRubyExec
+import com.github.jrubygradle.JRubyPrepare
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.BasePlugin
@@ -20,7 +21,7 @@ class CompassPlugin implements Plugin<Project> {
     project.afterEvaluate {
       def configuration = project.configurations.getByName(CONFIGURATION_NAME)
       if (!configuration.dependencies.any { it.name == "compass" }) {
-        project.dependencies.add(CONFIGURATION_NAME, "rubygems:compass:+")
+        project.dependencies.add(CONFIGURATION_NAME, "rubygems:compass:1.0.3")
       }
     }
 
@@ -59,7 +60,8 @@ class CompassPlugin implements Plugin<Project> {
       description "Generate a configuration file"
       command "config"
     }
-
+    project.task("compassPrepare", type: JRubyPrepare) {
+    }
     def extension = project.extensions.create("compass", CompassExtension, project)
 
     project.tasks.withType(CompassTaskOptions) { CompassTaskOptions task ->
@@ -91,7 +93,11 @@ class CompassPlugin implements Plugin<Project> {
     }
 
     project.afterEvaluate {
-      project.tasks.findByName("assemble").dependsOn("compassCompile")
+      project.compassPrepare.outputDir extension.gemDir
+      project.compassPrepare.dependencies project.configurations.getByName(CONFIGURATION_NAME)
+      project.compassCompile.dependsOn("compassPrepare");
+      project.compassWatch.dependsOn("compassPrepare");
+      project.assemble.dependsOn("compassCompile")
 
       [extension.sassDir, extension.cssDir, extension.imagesDir, extension.javascriptsDir, extension.fontsDir].each {
         if (it) {

--- a/src/main/groovy/com/github/robfletcher/compass/CompassTask.groovy
+++ b/src/main/groovy/com/github/robfletcher/compass/CompassTask.groovy
@@ -37,7 +37,6 @@ class CompassTask extends JRubyExec implements CompassTaskOptions {
 
   CompassTask() {
     script = new File("compass")
-    configuration = CONFIGURATION_NAME
     defaultCharacterEncoding = "UTF-8"
   }
 
@@ -47,21 +46,8 @@ class CompassTask extends JRubyExec implements CompassTaskOptions {
   }
 
   @Override
-  List<String> jrubyArgs() {
-    def jrubyArgs = super.jrubyArgs()
-    if (!jrubyArgs.contains("-S")) {
-      jrubyArgs << "-S"
-    }
-    return jrubyArgs
-  }
-
-  @Override
-  List<String> scriptArgs() {
-    ScriptArgumentsBuilder.compassArgs(this)
-  }
-
-  @Override
   List<String> getArgs() {
-    JRubyExecUtils.buildArgs(jrubyArgs(), script, scriptArgs())
+    List<String> extra = ['-I', jarDependenciesGemLibPath(getGemWorkDir())]
+    JRubyExecUtils.buildArgs(extra, jrubyArgs, getScript(), ScriptArgumentsBuilder.compassArgs(this))
   }
 }

--- a/src/main/groovy/com/github/robfletcher/compass/ScriptArgumentsBuilder.groovy
+++ b/src/main/groovy/com/github/robfletcher/compass/ScriptArgumentsBuilder.groovy
@@ -74,7 +74,7 @@ class ScriptArgumentsBuilder {
 
   ScriptArgumentsBuilder addGems(String flag, DependencySet dependencies) {
     dependencies.findAll { Dependency it ->
-      it.name != "compass"
+      it.name != "compass" && it.name != 'jruby-complete'
     } each {
       arguments << flag << it.name
     }

--- a/src/test/groovy/com/github/robfletcher/compass/ImagesSpec.groovy
+++ b/src/test/groovy/com/github/robfletcher/compass/ImagesSpec.groovy
@@ -18,7 +18,7 @@ class ImagesSpec extends CompassPluginSpec {
 
     then:
     with(stylesheet("build/stylesheets/image.css")) {
-      item(0).cssText == "*.chao { background: url(/images/sacred-chao.png) }"
+      item(0).cssText == ".chao { background: url(/images/sacred-chao.png) }"
     }
 
     and:
@@ -44,7 +44,7 @@ class ImagesSpec extends CompassPluginSpec {
 
     then:
     with(stylesheet("build/stylesheets/image.css")) {
-      item(0).cssText == "*.chao { background: url(/images/sacred-chao.png) }"
+      item(0).cssText == ".chao { background: url(/images/sacred-chao.png) }"
     }
   }
 
@@ -67,7 +67,7 @@ class ImagesSpec extends CompassPluginSpec {
 
     then:
     with(stylesheet("build/stylesheets/image.css")) {
-      item(0).cssText == "*.chao { background: url(../../images/sacred-chao.png) }"
+      item(0).cssText == ".chao { background: url(../../images/sacred-chao.png) }"
     }
   }
 
@@ -90,7 +90,7 @@ class ImagesSpec extends CompassPluginSpec {
 
     then:
     with(stylesheet("build/stylesheets/image.css")) {
-      item(0).cssText == "*.chao { width: 40px }"
+      item(0).cssText == ".chao { width: 40px }"
     }
   }
 

--- a/src/test/groovy/com/github/robfletcher/compass/RequireGemSpec.groovy
+++ b/src/test/groovy/com/github/robfletcher/compass/RequireGemSpec.groovy
@@ -5,7 +5,7 @@ class RequireGemSpec extends CompassPluginSpec {
   def setup() {
     buildFile << """
       dependencies {
-        compass "rubygems:modernizr-mixin:+"
+        compass "rubygems:modernizr-mixin:3.0.7"
       }
     """
   }
@@ -26,7 +26,7 @@ class RequireGemSpec extends CompassPluginSpec {
 
     then:
     with(stylesheet("build/stylesheets/extended.css")) {
-      item(0).cssText == "*.rgba body { background-color: rgba(0, 0, 0, 0.2) }"
+      item(0).cssText == ".rgba body { background-color: rgba(0, 0, 0, 0.2) }"
     }
   }
 

--- a/src/test/groovy/com/github/robfletcher/compass/TaskConfigurationSpec.groovy
+++ b/src/test/groovy/com/github/robfletcher/compass/TaskConfigurationSpec.groovy
@@ -29,7 +29,7 @@ class TaskConfigurationSpec extends Specification {
     task[property] == project.file(expectedPath)
 
     and:
-    with(task.scriptArgs()) {
+    with(ScriptArgumentsBuilder.compassArgs(task)) {
       def i = indexOf(argument)
       i >= 0
       get(i + 1) == "$project.rootDir/$expectedPath"
@@ -48,7 +48,7 @@ class TaskConfigurationSpec extends Specification {
     task[property] == null
 
     and:
-    !task.scriptArgs().contains(argument)
+    !ScriptArgumentsBuilder.compassArgs(task).contains(argument)
 
     where:
     property         | _
@@ -72,7 +72,7 @@ class TaskConfigurationSpec extends Specification {
     task[property] == project.file(path)
 
     and:
-    with(task.scriptArgs()) {
+    with(ScriptArgumentsBuilder.compassArgs(task)) {
       def i = indexOf(argument)
       i >= 0
       get(i + 1) == "$project.rootDir/$path"
@@ -102,7 +102,7 @@ class TaskConfigurationSpec extends Specification {
     task[property] == value
 
     and:
-    with(task.scriptArgs()) {
+    with(ScriptArgumentsBuilder.compassArgs(task)) {
       def i = indexOf(argument)
       i >= 0
       get(i + 1) == value
@@ -127,7 +127,7 @@ class TaskConfigurationSpec extends Specification {
     task.env == "production"
 
     and:
-    with(task.scriptArgs()) {
+    with(ScriptArgumentsBuilder.compassArgs(task)) {
       def i = indexOf("--environment")
       i >= 0
       get(i + 1) == "production"
@@ -139,7 +139,7 @@ class TaskConfigurationSpec extends Specification {
     task[property] == false
 
     and:
-    !task.scriptArgs().contains(argument)
+    !ScriptArgumentsBuilder.compassArgs(task).contains(argument)
 
     where:
     property         | _
@@ -166,7 +166,7 @@ class TaskConfigurationSpec extends Specification {
     task[property] == true
 
     and:
-    task.scriptArgs().contains(argument)
+    ScriptArgumentsBuilder.compassArgs(task).contains(argument)
 
     where:
     property         | _
@@ -192,7 +192,7 @@ class TaskConfigurationSpec extends Specification {
     }
 
     expect:
-    def args = task.scriptArgs()
+    def args = ScriptArgumentsBuilder.compassArgs(task)
     def indexes = args.findIndexValues { it == "--import-path" }
     indexes.collect { i -> args[((int) i) + 1] } == paths.collect { "$project.rootDir/$it" }
 


### PR DESCRIPTION
These changes upgrade to the latest version of jruby-gradle-plugin.  The version of jruby-gradle-plugin currently in use (0.1.9) relies on a torquebox proxy (http://rubygems-proxy.torquebox.org) to resolve dependencies, but at some point the plugin switched to a new proxy (http://rubygems.lasagna.io/).  At the time of this writing, the old version will produce an error when trying to resolve dependencies for a clean build and fail to run.

Most of the changes are catching up with the new jruby-gradle-plugin api.  There is one issue with dependencies like "rubygems:compass:+" so I had to hardcode to the latest version of compass to get it to work:
https://github.com/jruby-gradle/jruby-gradle-plugin/issues/267
Hardcoding the version works for now, but if a new version of compass is released the unit tests will fail.

I also had to tweak the css in the unit tests, the changes were due to subtle differences in how the latest version of compass builds css.

I noticed the WatchSpec doesn't always work, particularly with clean builds.  I don't think these changes caused the problem, but maybe the test frameworks should be rolled back to the original version if the Spec hasn't always been problematic.

This pull request updates all the dependencies except for bintray (0.6 -> 1.6) which I couldn't really test.  It also adds a plugin to check for new versions.